### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,14 +15,11 @@ export C_INCLUDE_PATH=/usr/include/gdal
 pip install -r requirements.txt
 
 sudo -u postgres psql
-postgres=# CREATE DATABASE census;
-postgres=# CREATE EXTENSION postgis;
 postgres=# CREATE USER census WITH PASSWORD '********';
-postgres=# GRANT ALL PRIVILEGES ON DATABASE "census" to census;
-postgres=# GRANT USAGE ON SCHEMA public TO census;
+postgres=# CREATE DATABASE census WITH OWNER census;
+postgres=# \c census
+postgres=# CREATE EXTENSION postgis;
 postgres=# \q
-psql -d census -U postgres
-census=# CREATE EXTENSION postgis;
 
 
 apt-get install -q -y memcached


### PR DESCRIPTION
Updated psql command sequence to simplify the process, and remove extraneous addition of postgis to the postgres database.

Setting the census user as the owner of the database allows it ownership of any additional schema that get created, without additional grants, and shouldn't negatively impact anything done by the postgres user, or other superusers on the system.